### PR TITLE
Add use the context to support the multiple cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # vim swap file
 *.swp
+
+.idea

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 BINARY_NAME=helm-wrapper
 
+GOPATH = $(shell go env GOPATH)
+
 LDFLAGS="-s -w"
 
 build:
@@ -13,3 +15,11 @@ build-linux:
 build-docker:
 	GOOS=linux GOARCH=amd64 go build -ldflags ${LDFLAGS} -o ${BINARY_NAME}
 	docker build -t helm-wrapper:`git rev-parse --short HEAD` .
+
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCILINT)
+	@echo
+	$(GOPATH)/bin/golangci-lint run
+
+$(GOLANGCILINT):
+	(cd /; GO111MODULE=on GOPROXY="direct" GOSUMDB=off go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.30.0)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ helm-wrapper is a helm3 HTTP wrapper with [helm Go SDK](https://helm.sh/docs/top
 
 ## Support API
 
+
+* If there are some APIs need to support multiple clusters,you can use the parameters below
+
+| Params | Description |
+| :- | :- |
+| kube_context | Support distinguish multiple clusters by the`kube_context`  |
+
+
+
 + helm install
     - `POST`
     - `/api/namespaces/:namespace/releases/:release?chart=<chartName>`
@@ -35,6 +44,8 @@ POST Body:
 + helm uninstall
     - `DELETE`
     - `/api/namespaces/:namespace/releases/:release`
+
+
 + helm upgrade
     - `PUT`
     - `/api/namespaces/:namespace/releases/:release?chart=<chartName>`
@@ -66,6 +77,8 @@ PUT Body:
 + helm rollback
     - `PUT`
     - `/api/namespaces/:namespace/releases/:release/versions/:reversion`
+
+
 + helm list
     - `GET`
     - `/api/namespaces/:namespace/releases`
@@ -86,7 +99,7 @@ Body:
     "superseded": false,        // `--superseded`
     "failed": false,            // `--failed`
     "deployed": false,          // `--deployed`
-    "pending": false,           // `--pending`
+    "pending": false            // `--pending`
 }
 ```
 
@@ -96,11 +109,12 @@ Body:
 
 | Params | Description |
 | :- | :- |
-| info | support all/hooks/manifest/notes/values | 
+| info | support all/hooks/manifest/notes/values |
 
 + helm release history
     - `GET`
     - `/api/namespaces/:namespace/releases/:release/histories`
+
 
 + helm show
     - `GET`

--- a/README_CN.md
+++ b/README_CN.md
@@ -4,6 +4,12 @@ Helm3 摒弃了 Helm2 的 Tiller 架构，使用纯命令行的方式执行相�
 
 ## Support API
 
+* 如果某些API需要支持多个集群，则可以使用以下参数
+
+| Params | Description |
+| :- | :- |
+| kube_context | 支持指定kube_context来区分不同集群 |
+
 helm 原生命令行和相关 API 对应关系：
 
 + helm install
@@ -35,6 +41,8 @@ POST Body:
 + helm uninstall
     - `DELETE`
     - `/api/namespaces/:namespace/releases/:release`
+
+
 + helm upgrade
     - `PUT`
     - `/api/namespaces/:namespace/releases/:release?chart=<chartName>`
@@ -67,6 +75,8 @@ PUT Body:
 + helm rollback
     - `PUT`
     - `/api/namespaces/:namespace/releases/:release/versions/:reversion`
+
+
 + helm list
     - `GET`
     - `/api/namespaces/:namespace/releases`
@@ -87,7 +97,7 @@ Body:
     "superseded": false,        // `--superseded`
     "failed": false,            // `--failed`
     "deployed": false,          // `--deployed`
-    "pending": false,           // `--pending`
+    "pending": false            // `--pending`
 }
 ```
 
@@ -97,11 +107,12 @@ Body:
 
 | Params | Description |
 | :- | :- |
-| info | 支持 all/hooks/manifest/notes/values 信息 | 
+| info | 支持 all/hooks/manifest/notes/values 信息 |
 
 + helm release history
     - `GET`
     - `/api/namespaces/:namespace/releases/:release/histories`
+
 
 + helm show
     - `GET`

--- a/main.go
+++ b/main.go
@@ -38,7 +38,10 @@ func main() {
 		config     string
 	)
 
-	flag.Set("logtostderr", "true")
+	err := flag.Set("logtostderr", "true")
+	if err != nil {
+		glog.Fatalln(err)
+	}
 	pflag.CommandLine.StringVar(&listenHost, "addr", "0.0.0.0", "server listen addr")
 	pflag.CommandLine.StringVar(&listenPort, "port", "8080", "server listen port")
 	pflag.CommandLine.StringVar(&config, "config", "config.yaml", "helm wrapper config")
@@ -104,12 +107,12 @@ func main() {
 		}
 	}()
 
-	quit := make(chan os.Signal)
+	quit := make(chan os.Signal, 2)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
 	glog.Infoln("Shutdown Server ...")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	srv.Shutdown(ctx)
+	_ = srv.Shutdown(ctx)
 }


### PR DESCRIPTION
Signed-off-by: aisuko <urakiny@gmail.com>

As we discussed, we use the `kube-context` to support the multiple cluster deployment.

There my test case below:


```
POST http://127.0.0.1:8080/api/namespaces/test-lb/releases/airflow?chart=bitnami/airflow

{
    "dry_run": false,
    "kube_context": "kind-cluster2",
    "create_namespace": true
}


GET http://127.0.0.1:8080/api/namespaces/test-lb/releases

{
    "dry_run": false,
    "kube_context": "kind-cluster2",
    "create_namespace": true
}

{
    "code": 0,
    "data": [
        {
            "name": "airflow",
            "namespace": "test-lb",
            "revision": "1",
            "updated": "2020-10-29 15:36:49.534551999 +0800 CST",
            "status": "deployed",
            "chart": "airflow",
            "chart_version": "6.7.1",
            "app_version": "1.10.12"
        }
    ]
}

DELETE http://127.0.0.1:8080/api/namespaces/test-lb/releases/airflow
{
    "dry_run": false,
    "kube_context": "kind-cluster3",
    "create_namespace": true
}

```


## Cluster2
```
NAMESPACE            NAME                                             READY   STATUS    RESTARTS   AGE
kube-system          coredns-66bff467f8-6p6b4                         1/1     Running   0          47h
kube-system          coredns-66bff467f8-fvbm4                         1/1     Running   0          47h
kube-system          etcd-cluster2-control-plane                      1/1     Running   0          47h
kube-system          kindnet-rd5hd                                    1/1     Running   0          47h
kube-system          kube-apiserver-cluster2-control-plane            1/1     Running   0          47h
kube-system          kube-controller-manager-cluster2-control-plane   1/1     Running   0          47h
kube-system          kube-proxy-dbdvh                                 1/1     Running   0          47h
kube-system          kube-scheduler-cluster2-control-plane            1/1     Running   0          47h
local-path-storage   local-path-provisioner-bd4bb6b75-q8gt8           1/1     Running   0          47h
test-lb              airflow-postgresql-0                             1/1     Running   0          100m
test-lb              airflow-redis-master-0                           1/1     Running   0          100m
test-lb              airflow-redis-slave-0                            1/1     Running   0          100m
test-lb              airflow-redis-slave-1                            1/1     Running   0          82m
test-lb              airflow-scheduler-6bcd776994-czhr2               1/1     Running   8          100m
test-lb              airflow-web-788b7ccd66-swwsv                     1/1     Running   0          100m
test-lb              airflow-worker-0                                 1/1     Running   4          100m

```

## Cluster3
```
NAMESPACE            NAME                                             READY   STATUS    RESTARTS   AGE
kube-system          coredns-66bff467f8-j5hlp                         1/1     Running   0          47h
kube-system          coredns-66bff467f8-wsnx5                         1/1     Running   0          47h
kube-system          etcd-cluster3-control-plane                      1/1     Running   0          47h
kube-system          helm-wrapper-57d444d46d-5xrs7                    1/1     Running   0          30h
kube-system          kindnet-vpknm                                    1/1     Running   0          47h
kube-system          kube-apiserver-cluster3-control-plane            1/1     Running   0          47h
kube-system          kube-controller-manager-cluster3-control-plane   1/1     Running   0          47h
kube-system          kube-proxy-l9n4r                                 1/1     Running   0          47h
kube-system          kube-scheduler-cluster3-control-plane            1/1     Running   0          47h
local-path-storage   local-path-provisioner-bd4bb6b75-hh6wk           1/1     Running   0          47h

```

