### PR TITLE
support MaxHistory for upgrade

### DIFF
--- a/releases.go
+++ b/releases.go
@@ -536,6 +536,7 @@ func upgradeRelease(c *gin.Context) {
 	client.Timeout = options.Timeout
 	client.Force = options.Force
 	client.Install = options.Install
+	client.MaxHistory = options.MaxHistory
 	client.Recreate = options.Recreate
 	client.ReuseValues = options.ReuseValues
 	client.CleanupOnFail = options.CleanupOnFail


### PR DESCRIPTION
Currently we are facing issue not able to invoke helm upgrade with the --max-history option.
We are hoping with this `--max-history` we could clean up the accumulated helm release history > 1000, which is causing helm list to timeout. 
