### PR TITLE
[Enable] Support options for helm uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,18 @@ POST Body:
     - `DELETE`
     - `/api/namespaces/:namespace/releases/:release`
 
+Delete Body:
+``` json 
+{
+    "dry_run": false,           // `--dry-run`
+    "disable_hooks": false,     // `--no-hooks`
+    "wait": false,              // `--wait`
+    "timeout": "5m0s",          // `--timeout`
+    "description": "",          // `--description`
+    "ignore_not_found": false,  // `--ignore-not-found`
+}
 
+```
 + helm upgrade
     - `PUT`
     - `/api/namespaces/:namespace/releases/:release?chart=<chartName>`

--- a/releases.go
+++ b/releases.go
@@ -439,11 +439,19 @@ func runInstall(name, namespace, kubeContext, aimChart, kubeConfig string, optio
 	return nil
 }
 
-func uninstallRelease(c *gin.Context, options releaseUninstallOptions) {
+func uninstallRelease(c *gin.Context) {
 	name := c.Param("release")
 	namespace := c.Param("namespace")
 	kubeContext := c.Query("kube_context")
 	kubeConfig := c.Query("kube_config")
+
+	var options releaseUninstallOptions
+
+	err := c.ShouldBindJSON(&options)
+	if err != nil && err != io.EOF {
+		respErr(c, err)
+		return
+	}
 
 	actionConfig, err := actionConfigInit(InitKubeInformation(namespace, kubeContext, kubeConfig))
 	if err != nil {
@@ -451,7 +459,6 @@ func uninstallRelease(c *gin.Context, options releaseUninstallOptions) {
 		return
 	}
 	client := action.NewUninstall(actionConfig)
-
 	client.DisableHooks = options.DisableHooks
 	client.DryRun = options.DryRun
 	client.IgnoreNotFound = options.IgnoreNotFound

--- a/releases.go
+++ b/releases.go
@@ -122,6 +122,18 @@ type releaseListOptions struct {
 	Pending      bool   `json:"pending"`
 }
 
+// helm Uninstall struct
+type releaseUninstallOptions struct {
+	DisableHooks        bool          `json:"disable_hooks"`
+	DryRun              bool          `json:"dry_run"`
+	IgnoreNotFound      bool          `json:"ignore_not_found"`
+	KeepHistory         bool          `json:"keep_history"`
+	Wait                bool          `json:"wait"`
+	DeletionPropagation string        `json:"delete_propagation"`
+	Timeout             time.Duration `json:"timeout"`
+	Description         string        `json:"description"`
+}
+
 func formatChartname(c *chart.Chart) string {
 	if c == nil || c.Metadata == nil {
 		// This is an edge case that has happened in prod, though we don't
@@ -427,7 +439,7 @@ func runInstall(name, namespace, kubeContext, aimChart, kubeConfig string, optio
 	return nil
 }
 
-func uninstallRelease(c *gin.Context) {
+func uninstallRelease(c *gin.Context, options releaseUninstallOptions) {
 	name := c.Param("release")
 	namespace := c.Param("namespace")
 	kubeContext := c.Query("kube_context")
@@ -439,6 +451,16 @@ func uninstallRelease(c *gin.Context) {
 		return
 	}
 	client := action.NewUninstall(actionConfig)
+
+	client.DisableHooks = options.DisableHooks
+	client.DryRun = options.DryRun
+	client.IgnoreNotFound = options.IgnoreNotFound
+	client.KeepHistory = options.KeepHistory
+	client.Wait = options.Wait
+	client.DeletionPropagation = options.DeletionPropagation
+	client.Timeout = options.Timeout
+	client.Description = options.Description
+
 	_, err = client.Run(name)
 	if err != nil {
 		respErr(c, err)


### PR DESCRIPTION
Currently the helm uninstall with helm-wrapper does not support any optional arguments.
The [helm client](https://helm.sh/docs/helm/helm_uninstall/) supports the following arguments 

     --description string   add a custom description

      --dry-run              simulate a uninstall

      --ignore-not-found     Treat "release not found" as a successful uninstall

      --keep-history         remove all associated resources and mark the release as deleted, but retain the release history

      --no-hooks             prevent hooks from running during uninstallation

      --timeout duration     time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)

      --wait                 if set, will wait until all the resources are deleted before returning. It will wait for as long as --timeout

Although the code for [uninstall.go](https://github.com/helm/helm/blob/3a3e3846ca9c929a6966583b461181e70f19bc13/cmd/helm/uninstall.go#L4) has conditional checks on the following options there is not support to pass these arguments before the Run command is executed
 