### PR TITLE
Don't assume that aimChart refers to an OCI registry.

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,4 +307,4 @@ helmRegistries:
 ```
 
 #### Helm settings registry config file
-Both of the previous methods will also create/update the registry config file (the same as the helm CLI).  However, you can also put this file in the container and helm-wrapper will use that to authenticate.  By default, this file is located at `/home/helm/.config/registry/config.json`.  Again, the domain must match the chart registry URL in the upgrade or install request.  Refer to helm documentation on how to configure this.  You can also use one of the other authentication methods and then look at the file that is created in the container.
+Both of the previous methods will also create/update the registry config file (the same as the helm CLI).  However, you can also put this file in the container and helm-wrapper will use that to authenticate.  By default, this file is located at `/home/helm/.config/helm/registry/config.json`.  Again, the domain must match the chart registry URL in the upgrade or install request.  Refer to helm documentation on how to configure this.  You can also use one of the other authentication methods and then look at the file that is created in the container.

--- a/registries.go
+++ b/registries.go
@@ -111,10 +111,14 @@ func initRegistry(c *repo.Entry) (error) {
 }
 
 func createOCIRegistryClientForChartPathOptions(aimChart *string, chartPathOptions *action.ChartPathOptions) (*registry.Client, error) {
-	registryConfig, err := chartPathOptionsToRegistryConfig(aimChart, chartPathOptions)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to convert chart path options to registry config: %s", err)
+	if strings.HasPrefix(*aimChart, "oci://") {
+		registryConfig, err := chartPathOptionsToRegistryConfig(aimChart, chartPathOptions)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to convert chart path options to registry config: %s", err)
+		}
+
+		return createOCIRegistryClient(registryConfig)
 	}
 
-	return createOCIRegistryClient(registryConfig)
+	return nil, nil
 }


### PR DESCRIPTION
I noticed an issue that I caused when adding OCI registry support.  It assumed that `aimChart` pointed to a chart in an OCI registry, so broke existing support of helm repositories.  This should fix that and only attempt to create an OCI registry client if the URL matches.  Otherwise, it works as it used to.